### PR TITLE
Player Movement Updates

### DIFF
--- a/Assets/Prefabs/Game Prefabs/Player.prefab
+++ b/Assets/Prefabs/Game Prefabs/Player.prefab
@@ -222,7 +222,7 @@ Rigidbody:
   m_GameObject: {fileID: 8498858998442318803}
   serializedVersion: 4
   m_Mass: 1
-  m_Drag: 1
+  m_Drag: 2
   m_AngularDrag: 0.05
   m_CenterOfMass: {x: 0, y: 0, z: 0}
   m_InertiaTensor: {x: 1, y: 1, z: 1}
@@ -252,12 +252,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 729564c76a524f94a9102e965667bb4f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  speed: 4
+  speed: 5
   health: 10
   invincibilityDuration: 5
   invincibilityDeltaTime: 0.15
   maxOil: 100
   oilConsumptionRate: 1
-  nitro: 304
+  nitro1: 304
+  nitro2: 303
   drift: 32
   minCrashSpeed: 3

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -27,12 +27,16 @@ public class Player : MonoBehaviour, ICrashable
     [SerializeField] float oilConsumptionRate = 1f;
 
     [Header("Input Key Codes")]
-    [Tooltip("Button for nitro")]
-    [SerializeField] private KeyCode nitro = KeyCode.LeftShift;
+    [Tooltip("Left button for nitro")]
+    [SerializeField] private KeyCode nitro1 = KeyCode.LeftShift;
+    [Tooltip("Right button for nitro")]
+    [SerializeField] private KeyCode nitro2 = KeyCode.RightShift;
     [Tooltip("Button for drifting")]
     [SerializeField] private KeyCode drift = KeyCode.Space;
 
+
     private Rigidbody rb;
+    private Vector3 lastVelocity;
     private float oil;
     private float[] angles = { 0, 45, 90, 135, 180, 225, 270, 315 };
     private int curAngle = 0;
@@ -41,6 +45,7 @@ public class Player : MonoBehaviour, ICrashable
     private bool isInvincible = false;
     private float turnDelay = 0;
     private float turnRate = 0.25f;
+    private float driftTime = 0;
 
     // Input booleans
     private bool pressForward;
@@ -68,6 +73,7 @@ public class Player : MonoBehaviour, ICrashable
 
     void FixedUpdate()
     {
+        lastVelocity = rb.velocity;
         Drive();
         Nitro();
         Drift();
@@ -107,7 +113,7 @@ public class Player : MonoBehaviour, ICrashable
         {
             pressLeft = false;
         }
-        if (Input.GetKey(nitro))
+        if (Input.GetKey(nitro1) || Input.GetKey(nitro2))
         {
             pressNitro = true;
         }
@@ -123,16 +129,21 @@ public class Player : MonoBehaviour, ICrashable
         {
             pressDrift = false;
         }
+        if (!pressRight && !pressLeft)
+        {
+            turnDelay = 0;
+        }
         if ((pressRight || pressLeft) && Time.time > turnDelay)
-        { 
+        {
             turnDelay = Time.time + turnRate;
-            Turn(); 
+            Turn();
         }
         if (customers.Count != 0)
         {
             HandleOrders();
         }
     }
+
 
     // While holding shift, the player uses oil to nitro boost.
     void Nitro()
@@ -232,14 +243,16 @@ public class Player : MonoBehaviour, ICrashable
     // Player can hold the spacebar to brake and turn while braking to drift
     void Drift()
     {
-        if (pressDrift)
+        if (pressDrift && (pressLeft || pressRight))
         {
-            if (movingForward && rb.velocity.magnitude > 0.01f)
-            {
-                rb.AddRelativeForce(-Vector3.forward * speed * 10);
-            }
+            driftTime = Time.time + 0.5f;
+        }
+        if (!pressDrift && driftTime > Time.time && movingForward)
+        {
+            rb.AddRelativeForce(Vector3.forward * 50);
         }
     }
+
 
     /// <summary>
     /// Called every frame to check through the list of customers and decrease cooking time and oil
@@ -328,5 +341,8 @@ public class Player : MonoBehaviour, ICrashable
         {
             other.gameObject.GetComponent<ICrashable>().Crash(rb.velocity, transform.position);
         }
+        float curSpeed = lastVelocity.magnitude;
+        Vector3 direction = Vector3.Reflect(lastVelocity.normalized, other.contacts[0].normal);
+        GetComponent<Rigidbody>().velocity = direction * Mathf.Max(curSpeed, 2f);
     }
 }


### PR DESCRIPTION
- Player can now tap turn to turn quickly
- Player can now boost after a drift
- Player can now use right shift for nitro
- Player bounces off of walls and objects now